### PR TITLE
Test/encode missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added documentation for running test cases.
 - Added test cases to verify that missing values in CSV will be encoded as empty strings in IRIDA Next JSON file in the sample metadata section.
+- Added test cases for passing missing values in a JSON file.
 
 # 0.2.0 - 2024/01/22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Added documentation for running test cases.
+- Added test cases to verify that missing values in CSV will be encoded as empty strings in IRIDA Next JSON file in the sample metadata section.
+
 # 0.2.0 - 2024/01/22
 
 - Added support for writing JSON output file when using `-resume` in a pipeline.

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Then the final IRIDA Next JSON file will preserve the empty string/null value in
 ```json
 "metadata": {
   "samples": {
-    "SAMPLE1": { "a": "", "b": "" }
+    "SAMPLE1": { "a": "value1", "b": "" }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ The following are the expectations for writing missing values in the final IRIDA
 
 #### Encoding missing metadata values using JSON
 
-If the metadata key `key` for **SAMPLE1** is encoded as an empty string `""` or `null` in the JSON file like the below example:
+If the metadata key `b` for **SAMPLE1** is encoded as an empty string `""` or `null` in the JSON file like the below example:
 
 **output.json**
 ```json
@@ -496,7 +496,7 @@ plugins {
 
 ## Run unit/integration tests
 
-In order to run the test cases, please glone this repository and run the following command:
+In order to run the test cases, please clone this repository and run the following command:
 
 ```bash
 ./gradlew check

--- a/README.md
+++ b/README.md
@@ -387,6 +387,73 @@ iridanext {
 }
 ```
 
+### Missing values in metadata
+
+There are two different scenarios where metadata key/value pairs could be missing for a sample, which result in different behaviours in IRIDA Next.
+
+1. **Ignore key**: If the `key` is left out of the samples metadata in the IRIDA Next JSON, then nothing is written for that `key` for the sample. Any existing metadata under that `key` will remain in IRIDA Next.
+
+2. **Delete key**: If a metadata value is an empty string (`"key": ""`) or null (`"key": null`), then IRIDA Next will remove that particular metadata key/value pair from the sample metadata if it exists. This is the expected scenario if pipeline results contain missing (or N/A) values (deleting older metadata keys prevents mixing up old and new pipeline analysis results in the metadata table).
+
+The following are the expectations for writing missing values in the final IRIDA Next JSON file (in order to delete the key/value pairs in IRIDA Next).
+
+#### Encoding missing metadata values using JSON
+
+If the metadata key `key` for **SAMPLE1** is encoded as an empty string `""` or `null` in the JSON file like the below example:
+
+**output.json**
+```json
+{
+  "SAMPLE1": {
+    "a": "value1",
+    "b": ""
+  }
+}
+```
+
+Then the final IRIDA Next JSON file will preserve the empty string/null value in the samples metadata section:
+
+**iridanext.output.json.gz**
+```json
+"metadata": {
+  "samples": {
+    "SAMPLE1": { "a": "", "b": "" }
+  }
+}
+```
+
+#### Encoding missing metadata values using CSV
+
+If the metadata key `b` for **SAMPLE1** is left empty in the CSV file like the below two examples:
+
+**output.csv** as table
+| column1 | b | c |
+|--|--|--|
+| SAMPLE1 |  | 3 |
+| SAMPLE2 | 4 | 5 |
+| SAMPLE3 | 6 | 7 |
+
+**output.csv** as CSV
+```
+column1,b,c
+SAMPLE1,,3
+SAMPLE2,4,5
+Sample3,6,7
+```
+
+Then the value for `b` for **SAMPLE1** will be written as an empty string in the IRIDA Next JSON file:
+
+**iridanext.output.json.gz**
+```json
+"metadata": {
+  "samples": {
+    "SAMPLE1": { "b": "", "c": "3" },
+    "SAMPLE2": { "b": "4", "c": "5" },
+    "SAMPLE3": { "b": "6", "c": "7" }
+  }
+}
+```
+
 # Development
 
 In order to build this plugin you will need a Java Development Kit (such as [OpenJDK](https://openjdk.org/)) and [Groovy](https://groovy-lang.org/index.html). For Ubuntu, this can be installed with:

--- a/README.md
+++ b/README.md
@@ -389,6 +389,12 @@ iridanext {
 
 # Development
 
+In order to build this plugin you will need a Java Development Kit (such as [OpenJDK](https://openjdk.org/)) and [Groovy](https://groovy-lang.org/index.html). For Ubuntu, this can be installed with:
+
+```bash
+sudo apt install default-jdk groovy
+```
+
 ## Build and install from source
 
 In order to build and install the plugin from source, please do the following:

--- a/README.md
+++ b/README.md
@@ -421,6 +421,20 @@ plugins {
 }
 ```
 
+## Run unit/integration tests
+
+In order to run the test cases, please glone this repository and run the following command:
+
+```bash
+./gradlew check
+```
+
+To get more information for any failed tests, please run:
+
+```bash
+./gradlew check --info
+```
+
 # Example: nf-core/fetchngs
 
 One use case of this plugin is to structure reads and metadata downloaded from NCBI/ENA for storage in IRIDA Next by making use of the [nf-core/fetchngs][nf-core/fetchngs] pipeline. The example configuration [fetchngs.conf][] can be used for this purpose. To test, please run the following (using [ids.csv][fetchngs-ids.csv] as example data accessions):

--- a/plugins/nf-iridanext/src/test/nextflow/iridanext/MetadataParserCSVTest.groovy
+++ b/plugins/nf-iridanext/src/test/nextflow/iridanext/MetadataParserCSVTest.groovy
@@ -5,6 +5,7 @@ import java.nio.file.FileSystems
 import nextflow.iridanext.MetadataParser
 import nextflow.iridanext.MetadataParserCSV
 import spock.lang.Specification
+import spock.lang.Ignore
 
 import nextflow.iridanext.TestHelper
 
@@ -69,5 +70,38 @@ class MetadataParserCSVTest extends Specification {
             "4": ["b": "5", "c": "6"]
         ]
         csvMapUnmatch == [:]
+    }
+
+    def 'Test parse CSV file with missing values' () {
+        when:
+        def csvContent = """a,b,c
+                           |1,2,
+                           |4,,""".stripMargin()
+        def csvFile = TestHelper.createInMemTempFile("temp.csv", csvContent)
+        def parser = new MetadataParserCSV("a", ",")
+        def csvMapColA = parser.parseMetadata(csvFile)
+
+        then:
+        csvMapColA == [
+            "1": ["b": "2", "c": ""],
+            "4": ["b": "", "c": ""]
+        ]
+    }
+
+    @Ignore
+    def 'Test parse CSV file with missing ids' () {
+        when:
+        def csvContent = """a,b,c
+                           |1,2,
+                           |4,,6""".stripMargin()
+        def csvFile = TestHelper.createInMemTempFile("temp.csv", csvContent)
+
+        parser = new MetadataParserCSV("b", ",")
+        def csvMapColB = parser.parseMetadata(csvFile)
+
+        then:
+        csvMapColB == [
+            "2": ["a": "1", "c": ""]
+        ]
     }
 }

--- a/plugins/nf-iridanext/src/test/nextflow/iridanext/MetadataParserCSVTest.groovy
+++ b/plugins/nf-iridanext/src/test/nextflow/iridanext/MetadataParserCSVTest.groovy
@@ -5,7 +5,7 @@ import java.nio.file.FileSystems
 import nextflow.iridanext.MetadataParser
 import nextflow.iridanext.MetadataParserCSV
 import spock.lang.Specification
-import spock.lang.Ignore
+import groovy.lang.MissingPropertyException
 
 import nextflow.iridanext.TestHelper
 
@@ -88,11 +88,10 @@ class MetadataParserCSVTest extends Specification {
         ]
     }
 
-    @Ignore
     def 'Test parse CSV file with missing ids' () {
         when:
         def csvContent = """a,b,c
-                           |1,2,
+                           |1,2,3
                            |4,,6""".stripMargin()
         def csvFile = TestHelper.createInMemTempFile("temp.csv", csvContent)
 
@@ -100,8 +99,8 @@ class MetadataParserCSVTest extends Specification {
         def csvMapColB = parser.parseMetadata(csvFile)
 
         then:
-        csvMapColB == [
-            "2": ["a": "1", "c": ""]
-        ]
+        // the column of identifiers is column "b", which has a missing value
+        // and so should trigger an exception
+        thrown(MissingPropertyException)
     }
 }

--- a/plugins/nf-iridanext/src/test/nextflow/iridanext/MetadataParserJSONTest.groovy
+++ b/plugins/nf-iridanext/src/test/nextflow/iridanext/MetadataParserJSONTest.groovy
@@ -46,4 +46,22 @@ class MetadataParserJSONTest extends Specification {
             "2": ["coords": ["x": 0, "y": 1], "coords.x": 4]
         ]
     }
+
+    def 'Test parse JSON file missing values' () {
+        when:
+        def jsonContent = '''{
+                            "1": {"b": "", "c": "3"},
+                            "2": {"b": "3", "c": null}
+                        }'''.stripMargin()
+
+        def jsonFile = TestHelper.createInMemTempFile("temp.json", jsonContent)
+        def parser = new MetadataParserJSON()
+        def outputData = parser.parseMetadata(jsonFile)
+
+        then:
+        outputData == [
+            "1": ["b": "", "c": "3"],
+            "2": ["b": "3", "c": null]
+        ]
+    }
 }


### PR DESCRIPTION
This adds test cases to confirm that missing values in a JSON/CSV file will be recorded as empty strings in sample metadata section of the `iridanext.output.json.gz` file. That is, if you have a CSV like the following:

**output.csv**
```
a,b,c
SAMPLE1,2,3
SAMPLE2,,5
```

Then the metadata entry for column `b` for **SAMPLE2** becomes `"b": ""` (that is an empty string).

**iridanext.output.json.gz**
```json
"metadata": {
  "samples": {
    "SAMPLE1": {"b": "2", "c": "3"},
    "SAMPLE2": {"b": "", "c": "5"}
  }
}
```

This will trigger IRIDA Next to delete this key/value pair from the sample (that is delete any existing metadata associated with key `b` for sample **SAMPLE2**).

For parsing JSON files for metadata, the missing values can be encoded as either empty strings `""` or `null` and these are preserved in the `iridanext.output.json.gz` file.

This PR updates the README with documentation describing the above and also includes some documentation on running the test suite.

Since the additional test cases all pass without code changes (i.e., the expected behaviour for missing data is working with the current release), there will be no new release made at this time.