### PR TITLE
Added a Channel Operator to Manually Load Sample IDs from a nf-validation-style Samplesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Then the value for `b` for **SAMPLE1** will be written as an empty string in the
 }
 ```
 
-### Manually loading metadata
+### Manually loading sample IDs
 
 The default behaviour of the plugin is to automatically observe completed tasks and identify the sample ID of the `meta` object associated with it. This sample ID is recorded and used when producing the metadata section in the `iridanext.output.json.gz` output.
 

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/IDParser.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/IDParser.groovy
@@ -1,0 +1,36 @@
+package nextflow.iridanext
+
+import groovyx.gpars.dataflow.DataflowWriteChannel
+import groovyx.gpars.dataflow.DataflowReadChannel
+import nextflow.Channel
+import nextflow.extension.CH
+import nextflow.extension.DataflowHelper
+import nextflow.Session
+import nextflow.plugin.extension.Operator
+import nextflow.plugin.extension.PluginExtensionPoint
+import nextflow.iridanext.IridaNextJSONOutput
+
+
+class IDParser extends PluginExtensionPoint {
+
+    @Override
+    void init(Session session) {}
+
+    @Operator
+    DataflowWriteChannel parseSamplesheet( DataflowReadChannel source ) {
+        final target = CH.createBy(source)
+
+        final next = { it ->
+            IridaNextJSONOutput.addId("samples", it[0].id)
+            target.bind(it)
+        }
+
+        final done = {
+            target.bind(Channel.STOP)
+        }
+
+        DataflowHelper.subscribeImpl(source, [onNext: next, onComplete: done])
+        return target
+    }
+    
+}

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextJSONOutput.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextJSONOutput.groovy
@@ -70,6 +70,13 @@ class IridaNextJSONOutput {
         return this.instance
     }
 
+    @Synchronized
+    public void reset() {
+        this.files = ["global": [], (SAMPLES): [:]]
+        this.metadata = [(SAMPLES): [:]]
+        this.scopeIds = [(SAMPLES): [] as Set<String>]
+    }
+
     public void setMetadataPostProcessor(MetadataPostProcessor processor) {
         this.metadataPostProcessor = processor
     }

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextJSONOutput.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextJSONOutput.groovy
@@ -37,16 +37,18 @@ import groovy.util.logging.Slf4j
 @Slf4j
 @CompileStatic
 class IridaNextJSONOutput {
-    private Map files = ["global": [], "samples": [:]]
-    private Map metadata = ["samples": [:]]
-    private static Map<String,Set<String>> scopeIds = ["samples": [] as Set<String>]
+    public static final Schema defaultSchema = loadDefaultOutputSchema()
+    public static final String SAMPLES = "samples"
+
+    private Map files = ["global": [], (SAMPLES): [:]]
+    private Map metadata = [(SAMPLES): [:]]
+    private static Map<String,Set<String>> scopeIds = [(SAMPLES): [] as Set<String>]
     private Path relativizePath
     private Boolean shouldRelativize
     private Schema jsonSchema
     private Boolean validate
     private MetadataPostProcessor metadataPostProcessor
 
-    public static final Schema defaultSchema = loadDefaultOutputSchema()
 
     public IridaNextJSONOutput(Path relativizePath = null,
         Schema jsonSchema = null, Boolean validate = false) {
@@ -123,9 +125,9 @@ class IridaNextJSONOutput {
         }
 
         def files_scope = files[scope]
-        if (scope == "samples" && subscope == null) {
+        if (scope == this.SAMPLES && subscope == null) {
             throw new Exception("scope=${scope} but subscope is null")
-        } else if (scope == "samples" && subscope != null) {
+        } else if (scope == this.SAMPLES && subscope != null) {
             assert isValidId(scope, subscope)
 
             def files_scope_map = (Map)files_scope
@@ -158,9 +160,9 @@ class IridaNextJSONOutput {
     }
 
     public String toJson() {
-        Map<String, Object> samplesMetadata = metadata["samples"]
+        Map<String, Object> samplesMetadata = metadata[this.SAMPLES]
         samplesMetadata = metadataPostProcessor.process(samplesMetadata)
-        Map newMetadata = ["samples": samplesMetadata]
+        Map newMetadata = [(this.SAMPLES): samplesMetadata]
         return JsonOutput.toJson(["files": files, "metadata": newMetadata])
     }
 

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextJSONOutput.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextJSONOutput.groovy
@@ -109,6 +109,7 @@ class IridaNextJSONOutput {
 
     public void setRelativizePath(Path relativizePath) {
         this.relativizePath = relativizePath
+        this.shouldRelativize = (this.relativizePath != null)
     }
 
     public void appendMetadata(String scope, Map data) {

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextJSONOutput.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextJSONOutput.groovy
@@ -39,7 +39,7 @@ import groovy.util.logging.Slf4j
 class IridaNextJSONOutput {
     private Map files = ["global": [], "samples": [:]]
     private Map metadata = ["samples": [:]]
-    private Map<String,Set<String>> scopeIds = ["samples": [] as Set<String>]
+    private static Map<String,Set<String>> scopeIds = ["samples": [] as Set<String>]
     private Path relativizePath
     private Boolean shouldRelativize
     private Schema jsonSchema
@@ -99,7 +99,7 @@ class IridaNextJSONOutput {
         }
     }
 
-    public void addId(String scope, String id) {
+    public static void addId(String scope, String id) {
         log.trace "Adding scope=${scope} id=${id}"
         scopeIds[scope].add(id)
     }

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextObserver.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/IridaNextObserver.groovy
@@ -211,7 +211,11 @@ class IridaNextObserver implements TraceObserver {
             this.samplesMetadataParsers = this.samplesMetadataParsers.findAll()
         }
 
-        iridaNextJSONOutput = new IridaNextJSONOutput(relativizePath, jsonSchema, validate)
+        iridaNextJSONOutput = IridaNextJSONOutput.getInstance()
+        iridaNextJSONOutput.setRelativizePath(relativizePath)
+        iridaNextJSONOutput.setOutputSchema(jsonSchema)
+        iridaNextJSONOutput.setValidate(validate)
+
         iridaNextJSONOutput.setMetadataPostProcessor(metadataPostProcessor)
     }
 

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/SamplesheetParser.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/SamplesheetParser.groovy
@@ -26,11 +26,24 @@ class SamplesheetParser extends PluginExtensionPoint {
         final IridaNextJSONOutput iridaNextJSONOutput = IridaNextJSONOutput.getInstance()
 
         final next = { it ->
-            // Check that it's a map and the id_key exists, ignore and warn otherwise / trace
-            def meta = it[0] // TODO: Check with workflow that's not just metadata
+            def meta = it[0]
             def id = meta[this.id_key]
 
-            iridaNextJSONOutput.addId(scope, id)
+            if(meta instanceof Map<String,Object>)
+            {
+                if(meta.containsKey(this.id_key))
+                {
+                    iridaNextJSONOutput.addId(scope, id)
+                }
+                else {
+                    throw new Exception("The expected key (${this.id_key}) was not found in the meta map.")
+                }
+
+            }
+            else {
+                throw new Exception("Expected a Map object in channel, but found ${meta}.")
+            }
+
             target.bind(it)
         }
 

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/SamplesheetParser.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/SamplesheetParser.groovy
@@ -9,8 +9,9 @@ import nextflow.Session
 import nextflow.plugin.extension.Operator
 import nextflow.plugin.extension.PluginExtensionPoint
 import nextflow.iridanext.IridaNextJSONOutput
+import groovy.util.logging.Slf4j
 
-
+@Slf4j
 class SamplesheetParser extends PluginExtensionPoint {
     private String id_key
 
@@ -27,21 +28,21 @@ class SamplesheetParser extends PluginExtensionPoint {
 
         final next = { it ->
             def meta = it[0]
-            def id = meta[this.id_key]
 
             if(meta instanceof Map<String,Object>)
             {
                 if(meta.containsKey(this.id_key))
                 {
+                    def id = meta[this.id_key]
                     iridaNextJSONOutput.addId(scope, id)
                 }
                 else {
-                    throw new Exception("The expected key (${this.id_key}) was not found in the meta map.")
+                    log.warn("The expected key (${this.id_key}) was not found in the meta map (${meta}).")
                 }
 
             }
             else {
-                throw new Exception("Expected a Map object in channel, but found ${meta}.")
+                log.warn("Expected a Map object in channel, but found ${meta}.")
             }
 
             target.bind(it)

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/SamplesheetParser.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/SamplesheetParser.groovy
@@ -11,17 +11,24 @@ import nextflow.plugin.extension.PluginExtensionPoint
 import nextflow.iridanext.IridaNextJSONOutput
 
 
-class IDParser extends PluginExtensionPoint {
+class SamplesheetParser extends PluginExtensionPoint {
+    private String id_key
 
     @Override
-    void init(Session session) {}
+    void init(Session session) {
+        this.id_key = session.config.navigate('iridanext.output.files.idkey', "id")
+    }
 
     @Operator
     DataflowWriteChannel parseSamplesheet( DataflowReadChannel source ) {
         final target = CH.createBy(source)
+        final String scope = IridaNextJSONOutput.SAMPLES
 
         final next = { it ->
-            IridaNextJSONOutput.addId("samples", it[0].id)
+            def meta = it[0]
+            def id = meta[this.id_key]
+
+            IridaNextJSONOutput.addId(scope, id)
             target.bind(it)
         }
 

--- a/plugins/nf-iridanext/src/main/nextflow/iridanext/SamplesheetParser.groovy
+++ b/plugins/nf-iridanext/src/main/nextflow/iridanext/SamplesheetParser.groovy
@@ -20,15 +20,17 @@ class SamplesheetParser extends PluginExtensionPoint {
     }
 
     @Operator
-    DataflowWriteChannel parseSamplesheet( DataflowReadChannel source ) {
+    DataflowWriteChannel loadIridaSampleIds( DataflowReadChannel source ) {
         final target = CH.createBy(source)
         final String scope = IridaNextJSONOutput.SAMPLES
+        final IridaNextJSONOutput iridaNextJSONOutput = IridaNextJSONOutput.getInstance()
 
         final next = { it ->
-            def meta = it[0]
+            // Check that it's a map and the id_key exists, ignore and warn otherwise / trace
+            def meta = it[0] // TODO: Check with workflow that's not just metadata
             def id = meta[this.id_key]
 
-            IridaNextJSONOutput.addId(scope, id)
+            iridaNextJSONOutput.addId(scope, id)
             target.bind(it)
         }
 

--- a/plugins/nf-iridanext/src/resources/META-INF/extensions.idx
+++ b/plugins/nf-iridanext/src/resources/META-INF/extensions.idx
@@ -1,1 +1,2 @@
 nextflow.iridanext.IridaNextObserverFactory
+nextflow.iridanext.IDParser

--- a/plugins/nf-iridanext/src/resources/META-INF/extensions.idx
+++ b/plugins/nf-iridanext/src/resources/META-INF/extensions.idx
@@ -1,2 +1,2 @@
 nextflow.iridanext.IridaNextObserverFactory
-nextflow.iridanext.IDParser
+nextflow.iridanext.SamplesheetParser

--- a/plugins/nf-iridanext/src/test/nextflow/iridanext/SamplesheetParserTest.groovy
+++ b/plugins/nf-iridanext/src/test/nextflow/iridanext/SamplesheetParserTest.groovy
@@ -84,8 +84,9 @@ class SamplesheetParserTest extends Dsl2Spec {
                 .of([["id":"sample1"]], [["id":"sample2"]], [["id":"sample3"]])
                 .loadIridaSampleIds()
             '''
-        
+
         final IridaNextJSONOutput iridaNextJSONOutput = IridaNextJSONOutput.getInstance()
+        iridaNextJSONOutput.reset() // Otherwise singleton class attributes persist across tests.
 
         and:
         def result = new MockScriptRunner([:]).setScript(SCRIPT).execute()
@@ -118,6 +119,7 @@ class SamplesheetParserTest extends Dsl2Spec {
             '''
         
         final IridaNextJSONOutput iridaNextJSONOutput = IridaNextJSONOutput.getInstance()
+        iridaNextJSONOutput.reset() // Otherwise singleton class attributes persist across tests.
 
         and:
         def result = new MockScriptRunner([:]).setScript(SCRIPT).execute()
@@ -126,6 +128,37 @@ class SamplesheetParserTest extends Dsl2Spec {
         iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample1")
         iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample2")
         iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample3")
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample4") == false
+    }
+
+    def 'Test no loadIridaSampleIds' () {
+        when:
+        def config = [
+            iridanext: [
+                enabled: true,
+                output: [
+                    path: "/tmp/output/output.json.gz"
+                ]
+            ]
+        ]
+        def session = Spy(Session) {
+            getConfig() >> config
+        }
+        def SCRIPT = '''
+            include { loadIridaSampleIds } from 'plugin/nf-iridanext'
+            channel.of([["id":"sample1"], "data1"], [["id":"sample2"], "data2"], [["id":"sample3"], "data3"])
+            '''
+        
+        final IridaNextJSONOutput iridaNextJSONOutput = IridaNextJSONOutput.getInstance()
+        iridaNextJSONOutput.reset() // Otherwise singleton class attributes persist across tests.
+
+        and:
+        def result = new MockScriptRunner([:]).setScript(SCRIPT).execute()
+
+        then:
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample1") == false
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample2") == false
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample3") == false
         iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample4") == false
     }
 }

--- a/plugins/nf-iridanext/src/test/nextflow/iridanext/SamplesheetParserTest.groovy
+++ b/plugins/nf-iridanext/src/test/nextflow/iridanext/SamplesheetParserTest.groovy
@@ -1,0 +1,131 @@
+package nextflow.iridanext
+
+import java.nio.file.Paths
+import java.nio.file.FileSystems
+import nextflow.iridanext.SamplesheetParser
+
+import nextflow.Session
+import spock.lang.Specification
+import net.jimblackler.jsonschemafriend.Schema
+import net.jimblackler.jsonschemafriend.SchemaStore
+import groovy.util.logging.Slf4j
+import groovyx.gpars.dataflow.DataflowReadChannel
+
+import nextflow.iridanext.TestHelper
+
+import java.nio.file.Files
+import java.util.jar.Manifest
+
+import nextflow.Channel
+import nextflow.plugin.Plugins
+import nextflow.plugin.TestPluginDescriptorFinder
+import nextflow.plugin.TestPluginManager
+import nextflow.plugin.extension.PluginExtensionProvider
+import org.pf4j.PluginDescriptorFinder
+import spock.lang.Shared
+import spock.lang.Timeout
+import test.Dsl2Spec
+
+import java.nio.file.Path
+
+
+@Slf4j
+class SamplesheetParserTest extends Dsl2Spec {
+
+    @Shared String pluginsMode
+
+    // NOTE: This setup() may fail if updated to Nextflow v24.01.
+    //       Please refer to these changes for a possible fix:
+    //       https://github.com/nextflow-io/nf-hello/commit/f686fbcf2346f3fc02b2288f567c016ab6bf2e50#diff-ae2fcafb7e787d2831f4cc882f85884ac2a100c5183b014baee656e96ddd69a6
+    def setup() {
+        // reset previous instances
+        PluginExtensionProvider.reset()
+        // this need to be set *before* the plugin manager class is created
+        pluginsMode = System.getProperty('pf4j.mode')
+        System.setProperty('pf4j.mode', 'dev')
+        // the plugin root should
+        def root = Path.of('.').toAbsolutePath().normalize()
+        def manager = new TestPluginManager(root){
+            @Override
+            protected PluginDescriptorFinder createPluginDescriptorFinder() {
+                return new TestPluginDescriptorFinder(){
+                    @Override
+                    protected Path getManifestPath(Path pluginPath) {
+                        return pluginPath.resolve('build/resources/main/META-INF/MANIFEST.MF')
+                    }
+                }
+            }
+        }
+        Plugins.init(root, 'dev', manager)
+    }
+
+    def cleanup() {
+        Plugins.stop()
+        PluginExtensionProvider.reset()
+        pluginsMode ? System.setProperty('pf4j.mode',pluginsMode) : System.clearProperty('pf4j.mode')
+    }
+
+    def 'Test loadIridaSampleIds only metadata' () {
+        when:
+        def config = [
+            iridanext: [
+                enabled: true,
+                output: [
+                    path: "/tmp/output/output.json.gz"
+                ]
+            ]
+        ]
+        def session = Spy(Session) {
+            getConfig() >> config
+        }
+        def SCRIPT = '''
+            include { loadIridaSampleIds } from 'plugin/nf-iridanext'
+            channel
+                .of([["id":"sample1"]], [["id":"sample2"]], [["id":"sample3"]])
+                .loadIridaSampleIds()
+            '''
+        
+        final IridaNextJSONOutput iridaNextJSONOutput = IridaNextJSONOutput.getInstance()
+
+        and:
+        def result = new MockScriptRunner([:]).setScript(SCRIPT).execute()
+
+        then:
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample1")
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample2")
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample3")
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample4") == false
+    }
+
+    def 'Test loadIridaSampleIds metadata and data' () {
+        when:
+        def config = [
+            iridanext: [
+                enabled: true,
+                output: [
+                    path: "/tmp/output/output.json.gz"
+                ]
+            ]
+        ]
+        def session = Spy(Session) {
+            getConfig() >> config
+        }
+        def SCRIPT = '''
+            include { loadIridaSampleIds } from 'plugin/nf-iridanext'
+            channel
+                .of([["id":"sample1"], "data1"], [["id":"sample2"], "data2"], [["id":"sample3"], "data3"])
+                .loadIridaSampleIds()
+            '''
+        
+        final IridaNextJSONOutput iridaNextJSONOutput = IridaNextJSONOutput.getInstance()
+
+        and:
+        def result = new MockScriptRunner([:]).setScript(SCRIPT).execute()
+
+        then:
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample1")
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample2")
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample3")
+        iridaNextJSONOutput.isValidId(iridaNextJSONOutput.SAMPLES, "sample4") == false
+    }
+}


### PR DESCRIPTION
Adds the `loadIridaSampleIds()` function which will manually load sample IDs into the set of valid sample IDs, thereby fixing a problem where certain workflows didn't automatically load sample IDs due to transformations and workflow design.

```
input = Channel.fromSamplesheet("input")
               .loadIridaSampleIds()
```

The channel operator outputs the input with no changes to the channel. However, it scans for `meta.id`s and adds them to the plugin's list of valid sample IDs.

See the updated README section for a more detailed description.